### PR TITLE
Fixed Bug: inconsistent use of relative/absolute URLs

### DIFF
--- a/client/components/activities/activities.jade
+++ b/client/components/activities/activities.jade
@@ -82,7 +82,7 @@ template(name="activity")
             +viewer
               = activity.checklist.title
         else
-          a.activity-checklist(href="{{ activity.card.absoluteUrl }}")
+          a.activity-checklist(href="{{ activity.card.originRelativeUrl }}")
             +viewer
               = activity.checklist.title
 
@@ -103,7 +103,7 @@ template(name="activity")
 
       if($eq activity.activityType 'addChecklistItem')
         | {{{_ 'activity-checklist-item-added' (sanitize activity.checklist.title) cardLink}}}.
-        .activity-checklist(href="{{ activity.card.absoluteUrl }}")
+        .activity-checklist(href="{{ activity.card.originRelativeUrl }}")
           +viewer
             = activity.checklistItem.title
 
@@ -139,7 +139,7 @@ template(name="activity")
         //- if we are not in card mode we only display a summary of the comment
         if($eq activity.activityType 'addComment')
           | {{{_ 'activity-on' cardLink}}}
-          a.activity-comment(href="{{ activity.card.absoluteUrl }}")
+          a.activity-comment(href="{{ activity.card.originRelativeUrl }}")
             +viewer
               = activity.comment.text
 
@@ -150,20 +150,20 @@ template(name="activity")
 
         if($eq activity.activityType 'a-startAt')
           | {{{_ 'activity-startDate' (sanitize startDate) cardLink}}}.
-        
+
         if($eq activity.activityType 'a-dueAt')
           | {{{_ 'activity-dueDate' (sanitize dueDate) cardLink}}}.
 
         if($eq activity.activityType 'a-endAt')
           | {{{_ 'activity-endDate' (sanitize endDate) cardLink}}}.
-      
+
       if($eq mode 'board')
         if($eq activity.activityType 'a-receivedAt')
           | {{{_ 'activity-receivedDate' (sanitize receivedDate) cardLink}}}.
 
         if($eq activity.activityType 'a-startAt')
           | {{{_ 'activity-startDate' (sanitize startDate) cardLink}}}.
-        
+
         if($eq activity.activityType 'a-dueAt')
           | {{{_ 'activity-dueDate' (sanitize dueDate) cardLink}}}.
 

--- a/client/components/activities/activities.js
+++ b/client/components/activities/activities.js
@@ -243,7 +243,7 @@ function createCardLink(card) {
     Blaze.toHTML(
       HTML.A(
         {
-          href: card.absoluteUrl(),
+          href: card.originRelativeUrl(),
           class: 'action-card',
         },
         sanitizeXss(card.title),
@@ -260,7 +260,7 @@ function createBoardLink(board, list) {
     Blaze.toHTML(
       HTML.A(
         {
-          href: board.absoluteUrl(),
+          href: board.originRelativeUrl(),
           class: 'action-board',
         },
         sanitizeXss(text),

--- a/client/components/cards/cardDetails.jade
+++ b/client/components/cards/cardDetails.jade
@@ -8,11 +8,11 @@ template(name="cardDetails")
           a.fa.fa-times-thin.close-card-details.js-close-card-details
           if currentUser.isBoardMember
             a.fa.fa-navicon.card-details-menu.js-open-card-details-menu
-            input.inline-input(type="text" id="cardURL_copy" value="{{ absoluteUrl }}")
+            input.inline-input(type="text" id="cardURL_copy" value="{{ originRelativeUrl }}")
             a.fa.fa-link.card-copy-button.js-copy-link(
               class="fa-link"
               title="{{_ 'copy-card-link-to-clipboard'}}"
-              value="{{ absoluteUrl }}"
+              value="{{ originRelativeUrl }}"
             )
         if isMiniScreen
           a.fa.fa-times-thin.close-card-details-mobile-web.js-close-card-details
@@ -533,7 +533,7 @@ template(name="cardMorePopup")
       span {{_ 'link-card'}}
       = ' '
       i.fa.colorful(class="{{#if board.isPublic}}fa-globe{{else}}fa-lock{{/if}}")
-      input.inline-input(type="text" id="cardURL" readonly value="{{ absoluteUrl }}" autofocus="autofocus")
+      input.inline-input(type="text" id="cardURL" readonly value="{{ originRelativeUrl }}" autofocus="autofocus")
       button.js-copy-card-link-to-clipboard(class="btn" id="clipboard") {{_ 'copy-card-link-to-clipboard'}}
     span.clearfix
     br

--- a/client/components/cards/resultCard.jade
+++ b/client/components/cards/resultCard.jade
@@ -1,6 +1,6 @@
 template(name="resultCard")
   .result-card-wrapper
-    a.minicard-wrapper.card-title(href=absoluteUrl)
+    a.minicard-wrapper.card-title(href=originRelativeUrl)
       +minicard(this)
       //= card.title
     ul.result-card-context-list

--- a/client/components/lists/listBody.jade
+++ b/client/components/lists/listBody.jade
@@ -5,7 +5,7 @@ template(name="listBody")
         +inlinedForm(autoclose=false position="top")
           +addCardForm(listId=_id position="top")
       each (cardsWithLimit (idOrNull ../../_id))
-        a.minicard-wrapper.js-minicard(href=absoluteUrl
+        a.minicard-wrapper.js-minicard(href=originRelativeUrl
           class="{{#if cardIsSelected}}is-selected{{/if}}"
           class="{{#if MultiSelection.isSelected _id}}is-checked{{/if}}")
           if MultiSelection.isActive

--- a/client/components/main/myCards.jade
+++ b/client/components/main/myCards.jade
@@ -30,8 +30,8 @@ template(name="myCards")
           each board in myCardsList
             .my-cards-board-wrapper
               .my-cards-board-title(class=board.colorClass, id="header")
-                a(href=board.absoluteUrl)
-                  +viewer 
+                a(href=board.originRelativeUrl)
+                  +viewer
                     = board.title
               each swimlane in board.mySwimlanes
                 .my-cards-swimlane-title(class="{{#if swimlane.colorClass}}{{ swimlane.colorClass }}{{else}}swimlane-default-color{{/if}}")
@@ -44,7 +44,7 @@ template(name="myCards")
                         = list.title
                     each card in list.myCards
                       .my-cards-card-wrapper
-                        a.minicard-wrapper(href=card.absoluteUrl)
+                        a.minicard-wrapper(href=card.originRelativeUrl)
                           +minicard(card)
         else
           .my-cards-dueat-list-wrapper

--- a/client/components/sidebar/sidebarSearches.jade
+++ b/client/components/sidebar/sidebarSearches.jade
@@ -4,9 +4,9 @@ template(name="searchSidebar")
   .list-body
     .minilists.clearfix.js-minilists
       each (lists)
-        a.minilist-wrapper.js-minilist(href=absoluteUrl)
+        a.minilist-wrapper.js-minilist(href=originRelativeUrl)
           +minilist(this)
     .minicards.clearfix.js-minicards
       each (results)
-        a.minicard-wrapper.js-minicard(href=absoluteUrl)
+        a.minicard-wrapper.js-minicard(href=originRelativeUrl)
           +minicard(this)

--- a/models/activities.js
+++ b/models/activities.js
@@ -136,7 +136,7 @@ if (Meteor.isServer) {
         params.board = '';
       }
       title = 'act-withBoardTitle';
-      params.url = board.absoluteUrl();
+      params.url = board.originRelativeUrl();
       params.boardId = activity.boardId;
     }
     if (activity.oldBoardId) {
@@ -179,7 +179,7 @@ if (Meteor.isServer) {
       watchers = _.union(watchers, card.watchers || []);
       params.card = card.title;
       title = 'act-withCardTitle';
-      params.url = card.absoluteUrl();
+      params.url = card.originRelativeUrl();
       params.cardId = activity.cardId;
     }
     if (activity.swimlaneId) {

--- a/models/boards.js
+++ b/models/boards.js
@@ -777,6 +777,9 @@ Boards.helpers({
   absoluteUrl() {
     return FlowRouter.url('board', { id: this._id, slug: this.slug });
   },
+  originRelativeUrl() {
+    return FlowRouter.path('board', { id: this._id, slug: this.slug });
+  },
 
   colorClass() {
     return `board-color-${this.color}`;

--- a/models/cards.js
+++ b/models/cards.js
@@ -758,6 +758,14 @@ Cards.helpers({
       cardId: this._id,
     });
   },
+  originRelativeUrl() {
+    const board = this.board();
+    return FlowRouter.path('card', {
+      boardId: board._id,
+      slug: board.slug,
+      cardId: this._id,
+    });
+  },
 
   canBeRestored() {
     const list = Lists.findOne({

--- a/models/lists.js
+++ b/models/lists.js
@@ -280,6 +280,10 @@ Lists.helpers({
     const card = Cards.findOne({ listId: this._id });
     return card && card.absoluteUrl();
   },
+  originRelativeUrl() {
+    const card = Cards.findOne({ listId: this._id });
+    return card && card.originRelativeUrl();
+  },
   remove() {
     Lists.remove({ _id: this._id });
   },


### PR DESCRIPTION
Some pages use relative links such as boards link at the home page.
 Others use absolute url such as cards in boards' lists.
 This commits goal is to allow for consistent use of relative
  urls.

Origin relative URLs also helps decoupling Wekan from the infrastructure
 it's deployed on. i.e if it's being served, it should work.